### PR TITLE
Fixes for imports

### DIFF
--- a/anfis/anfis.py
+++ b/anfis/anfis.py
@@ -6,7 +6,7 @@ Created on Thu Apr 03 07:30:34 2014
 """
 import itertools
 import numpy as np
-from anfis.membership import mfDerivs
+from membership import mfDerivs
 import copy
 
 class ANFIS:

--- a/anfis/membership/__init__.py
+++ b/anfis/membership/__init__.py
@@ -1,2 +1,2 @@
-import anfis.membership.membershipfunction
-import anfis.membership.mfDerivs
+import membership.membershipfunction
+import membership.mfDerivs

--- a/anfis/tests.py
+++ b/anfis/tests.py
@@ -19,5 +19,8 @@ print(round(anf.consequents[-2][0],6))
 print(round(anf.fittedValues[9][0],6))
 if round(anf.consequents[-1][0],6) == -5.275538 and round(anf.consequents[-2][0],6) == -1.990703 and round(anf.fittedValues[9][0],6) == 0.002249:
 	print('test is good')
+
+print("Plotting errors")
 anf.plotErrors()
+print("Plotting results")
 anf.plotResults()


### PR DESCRIPTION
Right now, any attempts to run anfis.py or tests.py "out of box" with python 3 result in "ModuleNotFoundError", caused by few incorrect imports (probably lasting from python 2 era). For example, people has mentioned this issue there: https://github.com/twmeggs/anfis/issues/8 
This pull request should hopefully fix said problem